### PR TITLE
fix(cloudfront): add WAF to becurrent.io CloudFront distribution (PRO-4323)

### DIFF
--- a/infra/cloudfront.yaml
+++ b/infra/cloudfront.yaml
@@ -4,6 +4,10 @@
 ####      - Cloudfront distribution
 #############################################################################
 
+Conditions:
+  # True only when a non-empty WAF ARN is provided (prd stage)
+  HasWebAcl: !Not [!Equals ["${param:webAclArn}", ""]]
+
 Resources:
   # ---------------------------------------------------------------------------
   # Bucket to receive cloudfront logs
@@ -205,4 +209,7 @@ Resources:
           AcmCertificateArn: ${param:domainNameCertArn}
           MinimumProtocolVersion: TLSv1.2_2019
           SslSupportMethod: sni-only
-        # WebACLId: String
+        WebACLId: !If
+          - HasWebAcl
+          - "${param:webAclArn}"
+          - !Ref "AWS::NoValue"

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,6 +24,8 @@ params:
   default:
     cognitoUserPoolGroupUsersId: users
     cognitoUserPoolGroupGovernorId: governors
+    # WAF WebACL ARN — prd uses cc-global-prd-cloudfront; dev has no WAF
+    webAclArn: ""
     # Name of the cloudformation stack
     stackName: cc-east-${self:provider.stage}-stack-kurteyt
     # Name of the api
@@ -41,6 +43,7 @@ params:
 
   prd:
     edgeHandler: edge.main.handler_prd
+    webAclArn: "arn:aws:wafv2:us-east-1:288020343544:global/webacl/cc-global-prd-cloudfront/50945332-f292-4cae-9e97-11aee07449d6"
     cognitoUserPoolClientsWeb: 26mf5j64glf9ri02fmpjqqgkhk
     cognitoUserPoolClientsServices: 3m83rvmir1a7qo8npivnci89a1
     cognitoUserPoolClientsInternal: ldnr04o1efig1kbbu2kgdfj84


### PR DESCRIPTION
## Summary

- The `becurrent.io` CloudFront distribution (E12MZGRLYOIE75) had no WAF — it was never codified in the CloudFormation template, so any stack update would silently drop a manual WAF association
- Adds `WebACLId` pointing to the `cc-global-prd-cloudfront` WebACL (same WAF used by the other distributions)
- A CloudFormation `Condition` gates the association so dev deployments (no WAF) continue to work unchanged
- The WAF ARN is stored as a stage-keyed param in `serverless.yml`

Fixes the Drata compliance failure reported in PRO-4323. Same pattern used to fix `app.currentclient.com` and `static.currentclient.com` in PRO-4132.

## Test plan

- [ ] Deploy to prd: `npm run deploy -- --stage prd`
- [ ] Confirm WAF is attached: `aws cloudfront get-distribution --id E12MZGRLYOIE75 --profile cc-prod --query "Distribution.DistributionConfig.WebACLId"`
- [ ] Verify dev deploy still works (no WAF applied)
- [ ] Confirm Drata check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)